### PR TITLE
Move algolia vars into env

### DIFF
--- a/src/docs/shared/helpers.ts
+++ b/src/docs/shared/helpers.ts
@@ -13,8 +13,8 @@ export const slugify = (text: string): string => {
 }
 
 // Index search
-const searchClient = algoliasearch('R538RETIHH', '57937335fdbc8f462f7e8ad277b4ed00');
-const index = searchClient.initIndex('netlify_61a5e8e4-0f4e-44c7-a2a2-1d9013d824e5_feature-ads-165_all');
+const searchClient = algoliasearch(process.env.REACT_APP_ALGOLIA_ID!, process.env.REACT_APP_ALGOLIA_KEY!);
+const index = searchClient.initIndex(process.env.REACT_APP_ALGOLIA_INDEX!);
 
 type Result = SearchResult & {
   description?: string;


### PR DESCRIPTION
The key is read-only so it doesn't strictly need to be hidden, but moving key (along with id and index name) into environment variables we end up with cleaner code, build good habits around keys, and can change these values easily without code changes + releases.