### PR TITLE
bug/ads-312: Text alternative for icon dropdown 

### DIFF
--- a/src/docs/components/variants/dropdown/AssertiveDropdown.tsx
+++ b/src/docs/components/variants/dropdown/AssertiveDropdown.tsx
@@ -12,7 +12,7 @@ const AssertiveDropdown = (): JSX.Element => {
         <Button>Action 2</Button>
         <Button>Action 3</Button>
       </Dropdown>
-      <Dropdown variant="assertive" icon="ellipsis">
+      <Dropdown variant="assertive" triggerText="Dropdown trigger" icon="ellipsis">
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 1</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 2</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 3</Button>

--- a/src/docs/components/variants/dropdown/DefaultStyleDropdown.tsx
+++ b/src/docs/components/variants/dropdown/DefaultStyleDropdown.tsx
@@ -12,7 +12,7 @@ const DefaultStyleDropdown = (): JSX.Element => {
         <Button>Action 2</Button>
         <Button>Action 3</Button>
       </Dropdown>
-      <Dropdown icon="ellipsis">
+      <Dropdown triggerText="Dropdown trigger" icon="ellipsis">
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 1</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 2</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 3</Button>

--- a/src/docs/components/variants/dropdown/GhostDropdown.tsx
+++ b/src/docs/components/variants/dropdown/GhostDropdown.tsx
@@ -12,7 +12,7 @@ const GhostDropdown = (): JSX.Element => {
         <Button>Action 2</Button>
         <Button>Action 3</Button>
       </Dropdown>
-      <Dropdown variant="ghost" icon="ellipsis">
+      <Dropdown variant="ghost" triggerText="Dropdown trigger" icon="ellipsis">
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 1</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 2</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 3</Button>

--- a/src/docs/components/variants/dropdown/IconDropdown.tsx
+++ b/src/docs/components/variants/dropdown/IconDropdown.tsx
@@ -7,7 +7,7 @@ const IconDropdown = (): JSX.Element => {
 
   return (
     <Example>
-      <Dropdown icon="ellipsis">
+      <Dropdown triggerText="Dropdown trigger" icon="ellipsis">
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 1</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 2</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 3</Button>

--- a/src/docs/components/variants/dropdown/SubtleDropdown.tsx
+++ b/src/docs/components/variants/dropdown/SubtleDropdown.tsx
@@ -12,7 +12,7 @@ const SubtleDropdown = (): JSX.Element => {
         <Button>Action 2</Button>
         <Button>Action 3</Button>
       </Dropdown>
-      <Dropdown variant="subtle" icon="ellipsis">
+      <Dropdown variant="subtle" triggerText="Dropdown trigger" icon="ellipsis">
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 1</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 2</Button>
         <Button><Icon name="plus" size="2x" className="bsds-icon-left" />Action 3</Button>

--- a/src/library/components/Breadcrumb.tsx
+++ b/src/library/components/Breadcrumb.tsx
@@ -47,7 +47,7 @@ const Breadcrumb = ({ crumbs, currentPage, texts, hasOverflow = true }: Props): 
         {overflowCrumbs.length > 0 &&
           <li className="bsds-breadcrumb-overflow">
             {overflowCrumbs.length > 0 &&
-              <Dropdown variant="subtle" icon="ellipsis" listType="ol" aria-label={texts?.breadcrumbDropdownAriaLabel || 'previous pages'}>
+              <Dropdown variant="subtle" triggerText={texts?.breadcrumbDropdownAriaLabel || 'previous pages'} icon="ellipsis" listType="ol">
                 {overflowCrumbs.map(crumb => (
                   <Link key={`crumb${crumb.name}`} href={crumb.href} to={crumb.to}>{crumb.name}</Link>
                 ))}

--- a/src/library/components/Dropdown.tsx
+++ b/src/library/components/Dropdown.tsx
@@ -7,7 +7,7 @@ import Icon from './icon/Icon';
 import { autoUpdate, flip, Placement, shift, useFloating } from '@floating-ui/react-dom';
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
-  triggerText?: string;
+  triggerText: string;
   listType?: 'ol' | 'ul';
   icon?: string;
   variant?: string;
@@ -201,10 +201,11 @@ const Dropdown = (props: Props) => {
         className={`bsds-dropdown-trigger${className ? ' ' + className : ''}${icon ? ' has-icon' : ''}`}
         aria-haspopup="true"
         aria-expanded={isDropdownOpen}
+        aria-label={icon ? triggerText : undefined}
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
         {...buttonAttrs}>
           {icon && <Icon size="2x" name={icon} />}
-          {triggerText}
+          {!icon && triggerText}
       </Button>
         {listType === 'ul' && (
           <ul


### PR DESCRIPTION
Added aria-label to dropdown with icon.
Dropdown triggerText is now a required prop to populate said aria-label. 

Ref: https://bsc-oit.atlassian.net/browse/ADS-312